### PR TITLE
fixed link to releases in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Foenix F256 firmware flash
 This repository is the distribution and development hub for the Foenix F256 line of modern retro computers. It pulls together the different components that make up the flash content, and includes the latest FPGA loads.
 
-**To download the latest firmware and FPGA loads**, please visit the [Releases](releases) page.
+**To download the latest firmware and FPGA loads**, please visit the https://github.com/FoenixRetro/f256-firmware/releases page.
 
 **For instructions on how to upgrade**, please see the [Upgrade](HowToUpgrade.md) document.
 


### PR DESCRIPTION
the previous link to the releases page led to a 404 missing page error. This fixed link should go to the right place.